### PR TITLE
feat: add data-layout option to start in vertical mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 npm-debug.log
 
 dist/
+
+tmp/

--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ All settings you can pass by HTML attributes.
     </pre>
     ```
 
+### `data-layout`
+
+* Default: `horizontal`
+* Options: `horizontal` | `vertical`
+* `horizontal` places the editor next to the result; `vertical` stacks the editor above the result.
+* Example:
+
+    ```html
+    <pre class="executor-editor" data-layout="vertical">
+        [...]
+    </pre>
+    ```
+
 ## Purpose
 
 The project was created for presentation slides, to embed code and quickly execute it.

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,7 +35,7 @@ console.log(String(new Cake()));
 
         <div class="executor-editor-demo">
 
-<pre class="executor-editor" data-skin="normal" data-autoevaluate="false">
+<pre class="executor-editor" data-skin="normal" data-autoevaluate="false" data-layout="vertical">
 class Animal {
     toString() {
         return '[Animal]';

--- a/src/scripts/manager.js
+++ b/src/scripts/manager.js
@@ -17,7 +17,8 @@ class Manager extends SuperEventEmitter {
     settings = {
         autoevaluate: true,
         autofocus: false,
-        skin: 'normal'
+        skin: 'normal',
+        layout: 'horizontal'
     };
 
     toolbar = null;
@@ -65,7 +66,11 @@ class Manager extends SuperEventEmitter {
     }
 
     _setupMode() {
-        this.$global.classList.add('executor-column-mode');
+        // `horizontal` (default) renders the editor next to the result
+        // (column layout); `vertical` stacks the editor above the result.
+        if (this.settings.layout !== 'vertical') {
+            this.$global.classList.add('executor-column-mode');
+        }
     }
 
     _setupEditor(listing) {


### PR DESCRIPTION
Closes #7

## Co

Nowa opcja `data-layout` pozwala wystartować edytor z pionowym układem (wynik pod kodem) zamiast domyślnego poziomego (wynik obok kodu).

| Wartość | Zachowanie |
| --- | --- |
| `horizontal` (domyślne) | edytor obok wyniku (`executor-column-mode`) — bez zmian względem dotychczasowego |
| `vertical` | edytor nad wynikiem (układ stacked) |

## Implementacja

- `manager.js`: dodany default `layout: 'horizontal'` w `settings`; `_setupMode()` dodaje klasę `executor-column-mode` tylko gdy layout != `vertical`. Opcja czytana automatycznie z `data-layout` przez istniejący `parseSettings` (bez zmian w parserze).
- README: nowa sekcja `data-layout` w stylu pozostałych opcji.
- demo: drugi edytor pokazuje `data-layout="vertical"`.

## Weryfikacja

- `npm run build` i `npm run lint` — przechodzą
- Playwright (headless), strona testowa z trzema edytorami:
  - `data-layout="vertical"` → brak `executor-column-mode` (stacked) ✓
  - `data-layout="horizontal"` → `executor-column-mode` ✓
  - brak atrybutu → `executor-column-mode` (domyślne, bez regresji) ✓