### PR TITLE
feat: add maximize mode to show only the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - ✅ Auto-evaluate the JavaScript code
 - ✅ Execute code on demand
 - ✅ Layout modes: `horizontal`, `vertical`
+- ✅ Maximize mode: show the code only
 - ✅ Multiple instance on single page
 - ✅ Support skins
 - ✅ Display errors in red color
@@ -114,6 +115,19 @@ All settings you can pass by HTML attributes.
 
     ```html
     <pre class="executor-editor" data-layout="vertical">
+        [...]
+    </pre>
+    ```
+
+### `data-maximize`
+
+* Default: `false`
+* Options: `true` | `false`
+* When `true`, the editor starts maximized: the result panel is hidden and the editor fills the component, useful to present code without running it. Toggle it at runtime with the `Maximize` button.
+* Example:
+
+    ```html
+    <pre class="executor-editor" data-maximize="true">
         [...]
     </pre>
     ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -47,6 +47,20 @@ console.log(String(new Animal()));
 
         </div>
 
+        <div class="executor-editor-demo">
+
+<pre class="executor-editor" data-skin="blue" data-autoevaluate="false" data-maximize="true">
+class Plant {
+    toString() {
+        return '[Plant]';
+    }
+}
+
+console.log(String(new Plant()));
+</pre>
+
+        </div>
+
         <h2>How to embed editor like that above?</h2>
 
 <pre class="embed-example language-html">

--- a/src/scripts/gui/toolbar/controls/maximize-button.js
+++ b/src/scripts/gui/toolbar/controls/maximize-button.js
@@ -1,0 +1,29 @@
+class MaximizeButton {
+    $el = null;
+    $button = null;
+
+    constructor() {
+        this.compile();
+    }
+
+    compile() {
+        this.$el = window.document.createDocumentFragment();
+
+        this.$button = window.document.createElement('input');
+        this.$button.type = 'button';
+        this.$button.classList.add('executor-maximize-button');
+        this.$button.value = 'Maximize';
+
+        // Helpful, when DOCTYPE is not defined.
+        this.$el.appendChild(window.document.createTextNode(' '));
+        this.$el.appendChild(this.$button);
+    }
+
+    setup(callback) {
+        this.$button.addEventListener('click', callback);
+    }
+}
+
+module.exports = {
+    MaximizeButton
+};

--- a/src/scripts/manager.js
+++ b/src/scripts/manager.js
@@ -6,6 +6,7 @@ const { Editor } = require('./editor');
 const { AutoEvaluateCheckbox } = require('./gui/toolbar/controls/auto-evaluate-checkbox');
 const { ExecuteButton } = require('./gui/toolbar/controls/execute-button');
 const { LayoutSwitcherButton } = require('./gui/toolbar/controls/layout-switcher-button');
+const { MaximizeButton } = require('./gui/toolbar/controls/maximize-button');
 const { ResultWindow } = require('./gui/result/result-window');
 const { VersionLabel } = require('./gui/version-label');
 
@@ -18,7 +19,8 @@ class Manager extends SuperEventEmitter {
         autoevaluate: true,
         autofocus: false,
         skin: 'normal',
-        layout: 'horizontal'
+        layout: 'horizontal',
+        maximize: false
     };
 
     toolbar = null;
@@ -27,6 +29,7 @@ class Manager extends SuperEventEmitter {
 
     autoEvaluate = null;
     layoutSwitcher = null;
+    maximizeButton = null;
     executeButton = null;
 
     resultsWindow = null;
@@ -71,6 +74,12 @@ class Manager extends SuperEventEmitter {
         if (this.settings.layout !== 'vertical') {
             this.$global.classList.add('executor-column-mode');
         }
+
+        // `maximize` hides the result and lets the editor fill the component,
+        // useful to present code without running it.
+        if (this.settings.maximize) {
+            this.$global.classList.add('executor-maximize-mode');
+        }
     }
 
     _setupEditor(listing) {
@@ -82,6 +91,7 @@ class Manager extends SuperEventEmitter {
     _buildDOM() {
         this.autoEvaluate = this.toolbar.add(new AutoEvaluateCheckbox());
         this.layoutSwitcher = this.toolbar.add(new LayoutSwitcherButton());
+        this.maximizeButton = this.toolbar.add(new MaximizeButton());
         this.executeButton = this.toolbar.add(new ExecuteButton());
 
         this.resultsWindow = new ResultWindow();
@@ -114,7 +124,10 @@ class Manager extends SuperEventEmitter {
         // Ad 2. Layout
         this.layoutSwitcher.setup(() => this._switchLayout());
 
-        // Ad 3. Execute
+        // Ad 3. Maximize
+        this.maximizeButton.setup(() => this._toggleMaximize());
+
+        // Ad 4. Execute
         this.executeButton.setup(() => this.runCode());
     }
 
@@ -150,6 +163,20 @@ class Manager extends SuperEventEmitter {
     _switchLayout() {
         this.$global.classList.toggle('executor-column-mode');
         this._resetAfterSwitchLayout();
+    }
+
+    _toggleMaximize() {
+        const maximized = this.$global.classList.toggle('executor-maximize-mode');
+        this.settings.maximize = maximized;
+
+        if (maximized) {
+            // Drop inline sizes left by `_switchLayout` so the maximize CSS
+            // (editor at 100%, result hidden) is not overridden.
+            this.editor.$el.style.width = '';
+            this.editor.$el.style.height = '';
+        } else {
+            this._resetAfterSwitchLayout();
+        }
     }
 
     _resetAfterSwitchLayout() {

--- a/src/styles/core/_editor.scss
+++ b/src/styles/core/_editor.scss
@@ -22,3 +22,10 @@
         height: 100%;
     }
 }
+
+.executor.executor-maximize-mode {
+    .executor-editor {
+        width: 100%;
+        height: 100%;
+    }
+}

--- a/src/styles/core/_result.scss
+++ b/src/styles/core/_result.scss
@@ -36,6 +36,12 @@ $resize-handle-bar-size: 16px;
     }
 }
 
+.executor.executor-maximize-mode {
+    .executor-result {
+        display: none;
+    }
+}
+
 .executor.executor-column-mode {
     .executor-result {
         width: 50%;

--- a/src/styles/core/_toolbar.scss
+++ b/src/styles/core/_toolbar.scss
@@ -34,6 +34,10 @@
                 cursor: pointer;
             }
 
+            .executor-maximize-button {
+                cursor: pointer;
+            }
+
             .executor-execute-button {
                 cursor: pointer;
             }


### PR DESCRIPTION
Closes #10

## Co

Nowy tryb `maximize`: ukrywa panel wyników i pozwala edytorowi wypełnić cały komponent — przydatne, by pokazać sam kod bez uruchamiania (np. na slajdach).

Udostępniony dwojako:
- **opcja startowa** `data-maximize="true"` — edytor startuje zmaksymalizowany
- **przycisk** `Maximize` w toolbarze — przełącza tryb w locie (jak `Switch layout`)

## Implementacja

- nowy `src/scripts/gui/toolbar/controls/maximize-button.js` (wzorowany na `execute-button.js`)
- `manager.js`: default `maximize: false`; `_setupMode()` dodaje klasę `executor-maximize-mode` gdy opcja włączona; `_toggleMaximize()` przełącza klasę i **czyści inline `width/height`** pozostawione przez `_switchLayout`, żeby CSS maximize nie był nadpisany
- CSS: `.executor-maximize-mode` → edytor 100%×100%, `.executor-result { display: none }`; `cursor: pointer` dla przycisku
- README: lista features + sekcja `data-maximize`
- demo: trzeci edytor z `data-maximize="true"`

## Weryfikacja (Playwright, headless)

- `data-maximize="true"` → klasa obecna, wynik `display:none` ✓
- bez atrybutu → wynik widoczny ✓
- przycisk toggluje ON/OFF, po OFF layout przywrócony ✓
- sekwencja `Switch layout` → `Maximize`: inline `width` wyczyszczone, maximize nie przebity ✓
- pełne demo (3 edytory: horizontal / vertical / maximize) renderuje się poprawnie, brak błędów runtime
- `npm run build` i `npm run lint` — przechodzą