### PR TITLE
test: add end-to-end tests with Playwright

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,18 @@ module.exports = {
         'sort-imports': 'off'
     },
 
+    // Relax rules that are noise in Playwright end-to-end tests.
+    overrides: [
+        {
+            files: ['e2e/**/*.js', 'playwright.config.js'],
+            rules: {
+                'no-magic-numbers': 'off',
+                'newline-per-chained-call': 'off',
+                'no-implicit-coercion': 'off'
+            }
+        }
+    ],
+
     // List of global variables.
     globals: {}
 };

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,6 +31,10 @@ jobs:
             - run: npm run build --if-present
             - run: npm run lint --if-present
             - run: npm test --if-present
+
+            - name: Install Playwright browsers
+              run: npx playwright install --with-deps chromium
+
             - run: npm run e2e --if-present
               env:
                   CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ npm-debug.log
 dist/
 
 tmp/
+
+playwright-report/
+test-results/
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ All settings you can pass by HTML attributes.
     </pre>
     ```
 
+## Testing
+
+End-to-end tests run in a real browser with [Playwright](https://playwright.dev/).
+
+```bash
+npm run build
+npx playwright install chromium
+npm run e2e
+```
+
+`npm run e2e` builds the bundle, serves it and drives `e2e/fixtures/index.html`
+in a headless browser. The tests cover initialization, the `data-*` options,
+the toolbar interactions and code execution.
+
 ## Purpose
 
 The project was created for presentation slides, to embed code and quickly execute it.

--- a/e2e/execution.spec.js
+++ b/e2e/execution.spec.js
@@ -1,0 +1,42 @@
+const { test, expect } = require('@playwright/test');
+
+const FIXTURE = '/e2e/fixtures/index.html';
+
+const AUTOEVAL = 5;
+const MANUAL = 6;
+
+test.describe('code execution and result', () => {
+    test('auto-evaluated editor prints its output on load', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const consoleEl = page.locator('.executor').nth(AUTOEVAL).locator('.executor-result-console');
+        await expect(consoleEl).toContainText('hello');
+    });
+
+    test('Execute button runs the code on demand', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const editor = page.locator('.executor').nth(MANUAL);
+        const consoleEl = editor.locator('.executor-result-console');
+
+        await expect(consoleEl).toBeEmpty();
+        await editor.locator('.executor-execute-button').click();
+        await expect(consoleEl).toContainText('manual');
+    });
+
+    test('runtime errors are rendered in the error style', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const editor = page.locator('.executor').nth(MANUAL);
+        const code = editor.locator('.executor-editor code');
+
+        // Replace the code with something that throws, typing so the editor
+        // registers the change, then run it.
+        await code.click();
+        await page.keyboard.press('Control+A');
+        await code.pressSequentially('throw new Error("boom");');
+        await editor.locator('.executor-execute-button').click();
+
+        await expect(editor.locator('.executor-result-console .executor-error')).toContainText('boom');
+    });
+});

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>executor-editor :: e2e fixture</title>
+
+    <link rel="stylesheet" href="/dist/executor-editor.css" type="text/css"/>
+    <link rel="stylesheet" href="/dist/skins/normal-skin.css" type="text/css"/>
+    <link rel="stylesheet" href="/dist/skins/blue-skin.css" type="text/css"/>
+</head>
+<body>
+<pre class="executor-editor" id="default" data-autoevaluate="false">var a = 1;</pre>
+
+<pre class="executor-editor" id="skin-blue" data-skin="blue" data-autoevaluate="false">var b = 2;</pre>
+
+<pre class="executor-editor" id="layout-vertical" data-layout="vertical" data-autoevaluate="false">var c = 3;</pre>
+
+<pre class="executor-editor" id="maximize" data-maximize="true" data-autoevaluate="false">var d = 4;</pre>
+
+<pre class="executor-editor" id="autofocus" data-autofocus="true" data-autoevaluate="false">var e = 5;</pre>
+
+<pre class="executor-editor" id="autoeval" data-autoevaluate="true">console.log('hello');</pre>
+
+<pre class="executor-editor" id="manual" data-autoevaluate="false">console.log('manual');</pre>
+
+<script src="/dist/executor-editor.js"></script>
+<script>ExecutorEditor.setup();</script>
+</body>
+</html>

--- a/e2e/init.spec.js
+++ b/e2e/init.spec.js
@@ -1,0 +1,46 @@
+const { test, expect } = require('@playwright/test');
+
+const FIXTURE = '/e2e/fixtures/index.html';
+
+test.describe('initialization and render', () => {
+    test('replaces every <pre> with a rendered editor', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        // The fixture declares 7 editors.
+        await expect(page.locator('.executor')).toHaveCount(7);
+    });
+
+    test('each editor renders toolbar, editor and result panels', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const first = page.locator('.executor').first();
+        await expect(first.locator('.executor-toolbar')).toHaveCount(1);
+        await expect(first.locator('.executor-editor')).toHaveCount(1);
+        await expect(first.locator('.executor-result')).toHaveCount(1);
+    });
+
+    test('toolbar exposes the expected controls', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const first = page.locator('.executor').first();
+        await expect(first.locator('.executor-autoevaluate-checkbox')).toHaveCount(1);
+        await expect(first.locator('.executor-layout-switcher-button')).toHaveCount(1);
+        await expect(first.locator('.executor-maximize-button')).toHaveCount(1);
+        await expect(first.locator('.executor-execute-button')).toHaveCount(1);
+    });
+
+    test('loads without console errors', async ({ page }) => {
+        const errors = [];
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') {
+                errors.push(msg.text());
+            }
+        });
+        page.on('pageerror', (err) => errors.push(err.message));
+
+        await page.goto(FIXTURE);
+        await expect(page.locator('.executor').first()).toBeVisible();
+
+        expect(errors).toEqual([]);
+    });
+});

--- a/e2e/interactions.spec.js
+++ b/e2e/interactions.spec.js
@@ -1,0 +1,67 @@
+const { test, expect } = require('@playwright/test');
+
+const FIXTURE = '/e2e/fixtures/index.html';
+
+const DEFAULT = 0;
+
+test.describe('toolbar interactions', () => {
+    test('Switch layout toggles column mode', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const editor = page.locator('.executor').nth(DEFAULT);
+        await expect(editor).toHaveClass(/executor-column-mode/);
+
+        await editor.locator('.executor-layout-switcher-button').click();
+        await expect(editor).not.toHaveClass(/executor-column-mode/);
+
+        await editor.locator('.executor-layout-switcher-button').click();
+        await expect(editor).toHaveClass(/executor-column-mode/);
+    });
+
+    test('Maximize toggles maximize mode and result visibility', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const editor = page.locator('.executor').nth(DEFAULT);
+        const result = editor.locator('.executor-result');
+        await expect(editor).not.toHaveClass(/executor-maximize-mode/);
+        await expect(result).toBeVisible();
+
+        await editor.locator('.executor-maximize-button').click();
+        await expect(editor).toHaveClass(/executor-maximize-mode/);
+        await expect(result).toBeHidden();
+
+        await editor.locator('.executor-maximize-button').click();
+        await expect(editor).not.toHaveClass(/executor-maximize-mode/);
+        await expect(result).toBeVisible();
+    });
+
+    test('Maximize after Switch layout is not overridden by inline sizes', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const editor = page.locator('.executor').nth(DEFAULT);
+
+        // Switch layout sets inline width/height on the editor.
+        await editor.locator('.executor-layout-switcher-button').click();
+        // Maximize must clear those so its CSS (editor at 100%) takes effect.
+        await editor.locator('.executor-maximize-button').click();
+
+        await expect(editor).toHaveClass(/executor-maximize-mode/);
+        const inlineWidth = await editor.locator('.executor-editor').evaluate((el) => el.style.width);
+        expect(inlineWidth).toBe('');
+    });
+
+    test('autoevaluate checkbox is checked when data-autoevaluate is true', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        // Editor index 5 has data-autoevaluate="true".
+        const editor = page.locator('.executor').nth(5);
+        await expect(editor.locator('.executor-autoevaluate-checkbox')).toBeChecked();
+    });
+
+    test('autoevaluate checkbox is unchecked when data-autoevaluate is false', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const editor = page.locator('.executor').nth(DEFAULT);
+        await expect(editor.locator('.executor-autoevaluate-checkbox')).not.toBeChecked();
+    });
+});

--- a/e2e/options.spec.js
+++ b/e2e/options.spec.js
@@ -1,0 +1,55 @@
+const { test, expect } = require('@playwright/test');
+
+const FIXTURE = '/e2e/fixtures/index.html';
+
+// Editors keep the document order of the source `<pre>` elements.
+const DEFAULT = 0;
+const SKIN_BLUE = 1;
+const LAYOUT_VERTICAL = 2;
+const MAXIMIZE = 3;
+
+test.describe('options from data-* attributes', () => {
+    test('data-skin defaults to normal and can be set to blue', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const editors = page.locator('.executor');
+        await expect(editors.nth(DEFAULT)).toHaveClass(/skin-normal/);
+        await expect(editors.nth(SKIN_BLUE)).toHaveClass(/skin-blue/);
+    });
+
+    test('data-layout default is horizontal (column mode)', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        await expect(page.locator('.executor').nth(DEFAULT)).toHaveClass(/executor-column-mode/);
+    });
+
+    test('data-layout="vertical" drops column mode (stacked)', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        await expect(page.locator('.executor').nth(LAYOUT_VERTICAL)).not.toHaveClass(/executor-column-mode/);
+    });
+
+    test('data-maximize="true" hides the result panel', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const editor = page.locator('.executor').nth(MAXIMIZE);
+        await expect(editor).toHaveClass(/executor-maximize-mode/);
+        await expect(editor.locator('.executor-result')).toBeHidden();
+    });
+
+    test('default editors keep the result panel visible', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        await expect(page.locator('.executor').nth(DEFAULT).locator('.executor-result')).toBeVisible();
+    });
+
+    test('data-autofocus focuses the editable code area', async ({ page }) => {
+        await page.goto(FIXTURE);
+
+        const focusedHasCode = await page.evaluate(() => {
+            const active = document.activeElement;
+            return !!active && active.closest('.executor-editor') !== null;
+        });
+        expect(focusedHasCode).toBe(true);
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
                 "@babel/core": "^7.29.7",
                 "@babel/eslint-parser": "^7.29.7",
                 "@babel/preset-env": "^7.29.7",
+                "@playwright/test": "^1.61.0",
                 "babel-loader": "^10.1.1",
                 "debounce": "^1.2.1",
                 "escape-html": "^1.0.3",
                 "eslint": "^8.57.1",
                 "eslint-config-piecioshka": "^2.3.7",
+                "http-server": "^14.1.1",
                 "npm-run-all": "^4.1.5",
                 "sass": "^1.101.0",
                 "selection-range": "^1.1.0",
@@ -2140,6 +2142,22 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/@playwright/test": {
+            "version": "1.61.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+            "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.61.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2513,6 +2531,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/async": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/async-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2625,6 +2650,19 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/basic-auth": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+            "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/brace-expansion": {
@@ -2884,6 +2922,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
+            }
+        },
+        "node_modules/corser": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+            "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4.0"
             }
         },
         "node_modules/cross-spawn": {
@@ -3536,6 +3584,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3656,6 +3711,27 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/follow-redirects": {
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/for-each": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3678,6 +3754,21 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -3996,12 +4087,91 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
+            }
+        },
         "node_modules/hosted-git-info": {
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/html-encoding-sniffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+            "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-encoding": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/http-proxy": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/http-server": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+            "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "basic-auth": "^2.0.1",
+                "chalk": "^4.1.2",
+                "corser": "^2.0.1",
+                "he": "^1.2.0",
+                "html-encoding-sniffer": "^3.0.0",
+                "http-proxy": "^1.18.1",
+                "mime": "^1.6.0",
+                "minimist": "^1.2.6",
+                "opener": "^1.5.1",
+                "portfinder": "^1.0.28",
+                "secure-compare": "3.0.1",
+                "union": "~0.5.0",
+                "url-join": "^4.0.1"
+            },
+            "bin": {
+                "http-server": "bin/http-server"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/ignore": {
             "version": "5.3.2",
@@ -4808,6 +4978,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/mime-db": {
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -4829,6 +5012,16 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/ms": {
@@ -5131,6 +5324,16 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/opener": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+            "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+            "dev": true,
+            "license": "(WTFPL OR MIT)",
+            "bin": {
+                "opener": "bin/opener-bin.js"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5399,6 +5602,52 @@
                 "node": ">=8"
             }
         },
+        "node_modules/playwright": {
+            "version": "1.61.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+            "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.61.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.61.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+            "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/portfinder": {
+            "version": "1.0.38",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+            "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "async": "^3.2.6",
+                "debug": "^4.3.6"
+            },
+            "engines": {
+                "node": ">= 10.12"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5427,6 +5676,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/queue-microtask": {
@@ -5604,6 +5869,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/resolve": {
             "version": "1.22.12",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -5731,6 +6003,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5765,6 +6044,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/sass": {
             "version": "1.101.0",
@@ -5841,6 +6127,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/secure-compare": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+            "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
             "dev": true,
             "license": "MIT"
         },
@@ -6545,6 +6838,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/union": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+            "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+            "dev": true,
+            "dependencies": {
+                "qs": "^6.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -6585,6 +6890,13 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
+        },
+        "node_modules/url-join": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
@@ -6730,6 +7042,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+            "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -22,17 +22,20 @@
         "watch:js": "webpack -w",
         "watch:css": "./tools/styles-watch.sh",
         "dev": "npm run build",
-        "lint": "eslint ."
+        "lint": "eslint .",
+        "e2e": "playwright test"
     },
     "devDependencies": {
         "@babel/core": "^7.29.7",
         "@babel/eslint-parser": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
+        "@playwright/test": "^1.61.0",
         "babel-loader": "^10.1.1",
         "debounce": "^1.2.1",
         "escape-html": "^1.0.3",
         "eslint": "^8.57.1",
         "eslint-config-piecioshka": "^2.3.7",
+        "http-server": "^14.1.1",
         "npm-run-all": "^4.1.5",
         "sass": "^1.101.0",
         "selection-range": "^1.1.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,33 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+const PORT = 8080;
+const BASE_URL = `http://localhost:${PORT}`;
+
+module.exports = defineConfig({
+    testDir: './e2e',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    reporter: process.env.CI ? 'list' : 'html',
+
+    use: {
+        baseURL: BASE_URL,
+        trace: 'on-first-retry'
+    },
+
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] }
+        }
+    ],
+
+    // The demo page loads the freshly built bundle from `../dist`, so the
+    // bundle must be built before the static server starts.
+    webServer: {
+        command: `npm run build && npx http-server . -p ${PORT} -c-1 --silent`,
+        url: BASE_URL,
+        timeout: 120 * 1000,
+        reuseExistingServer: !process.env.CI
+    }
+});


### PR DESCRIPTION
Closes #15

## Co

Pakiet nie miał żadnych testów. Dodaje suite end-to-end w Playwright, który steruje dedykowaną stroną-fixture w przeglądarce headless.

Pokrycie (18 testów, wszystkie zielone lokalnie):

| Obszar | Co sprawdza |
| --- | --- |
| Inicjalizacja / render | 7 edytorów renderuje się, toolbar + editor + result obecne, brak błędów w konsoli |
| Opcje `data-*` | `data-skin`, `data-layout` (horizontal/vertical), `data-maximize`, `data-autoevaluate`, `data-autofocus` |
| Interakcje | `Switch layout`, `Maximize` (toggle + sekwencja po switch layout), checkbox auto-evaluate |
| Wykonanie kodu | auto-evaluate na starcie, `Execute` na żądanie, błędy runtime w stylu `.executor-error` |

## Implementacja

- `playwright.config.js`: `webServer` buduje bundle (`npm run build`) i serwuje przez `http-server`, więc `npm run e2e` jest samowystarczalne; `testDir: e2e/`, projekt chromium, retry w CI
- `e2e/fixtures/index.html`: kontrolowana strona z 7 edytorami pokrywającymi warianty opcji
- `e2e/*.spec.js`: 4 pliki (init / options / interactions / execution)
- `package.json`: skrypt `e2e`, devDeps `@playwright/test` + `http-server`
- CI (`testing.yml`): krok `npx playwright install --with-deps chromium` przed `npm run e2e --if-present` (haki w workflow już istniały)
- `.eslintrc.js`: overrides rozluźniające reguły szumowe tylko dla testów; `.gitignore` ignoruje artefakty Playwright
- README: sekcja Testing

## Weryfikacja

```
18 passed (8.9s)
```

`npm run lint` i `npm run build` — przechodzą. Testy e2e nie trafiają do paczki npm (whitelist `files` obejmuje tylko `dist/src/package.json/README.md`).